### PR TITLE
Fix: Windows build fails due to App.tsx/app/ case collision

### DIFF
--- a/frontend/src/Root.tsx
+++ b/frontend/src/Root.tsx
@@ -3,7 +3,7 @@ import { AppProviders, AppRoutes } from '@/app'
 import { ErrorBoundary } from '@/shared/components'
 import { applyFont, applyTheme, getSavedFont, getSavedTheme } from '@/shared/lib'
 
-export default function App() {
+export default function Root() {
   // Simple theme bootstrap: read localStorage and set class on <html>
   useEffect(() => {
     applyTheme(getSavedTheme())

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter } from 'react-router-dom'
-import App from './App'
+import Root from './Root'
 import './index.css'
 
 const container = document.getElementById('root')
@@ -11,7 +11,7 @@ const root = createRoot(container!)
 root.render(
   <StrictMode>
     <HashRouter basename={"/"}>
-      <App />
+      <Root />
     </HashRouter>
   </StrictMode>
 )


### PR DESCRIPTION
## Summary

`wails dev` fails on Windows during the frontend TypeScript step because `src/App.tsx` (the root component) and `src/app/` (a module directory) collide on case-insensitive filesystems.

## Repro

On Windows, after `wails dev`:

```
src/App.tsx(2,10): error TS2614: Module '"@/app"' has no exported member 'AppProviders'. Did you mean to use 'import AppProviders from "@/app"' instead?
src/App.tsx(2,24): error TS2614: Module '"@/app"' has no exported member 'AppRoutes'. Did you mean to use 'import AppRoutes from "@/app"' instead?
src/App.tsx(2,41): error TS1149: File name 'src/app.tsx' differs from already included file name 'src/App.tsx' only in casing.
```

## Cause

On case-insensitive filesystems (Windows, default macOS), TypeScript's module resolution treats `App.tsx` and `app/` as the same path. `import { AppProviders, AppRoutes } from '@/app'` ends up pointing at `App.tsx` instead of `app/index.ts`, which is why neither `AppProviders` nor `AppRoutes` is found. `forceConsistentCasingInFileNames: true` in `tsconfig.json` then surfaces the TS1149 diagnostic.

The Dev Container (Linux) doesn't hit this because its filesystem is case-sensitive — the two paths are simply distinct.

## Fix

Rename `frontend/src/App.tsx` to `frontend/src/Root.tsx` (and the exported component from `App` to `Root`). The only consumer of this file is `main.tsx`, so the change is local. The `src/app/` directory and all `@/app` imports are untouched.

## Verification

- `npm run build` (i.e. `tsc && vite build`) now passes on Windows without errors.
- No other files reference `./App` or `@/App`.

## Test plan
- [ ] `wails dev` starts the app on Windows without TypeScript errors
- [ ] App behaves identically to before (rename-only change, no logic touched)