### PR TITLE
Expand sensitivity conversion to cover most Kovaak's-supported game scales

### DIFF
--- a/internal/constants/defaults.go
+++ b/internal/constants/defaults.go
@@ -1,5 +1,7 @@
 package constants
 
+import "math"
+
 const (
 	// Default UI/analysis values
 	DefaultSessionGapMinutes  = 20
@@ -32,13 +34,33 @@ const (
 	// by the sensitivity converter to derive cm/360 for linear engines where
 	// rotation = sensitivity * yaw * counts.
 
-	// Source-family yaw (0.022 deg/count) shared by Counter-Strike, CSGO,
+	// Source family yaw (0.022 deg/count) shared by Counter-Strike, CSGO,
 	// Apex Legends, Quake/Source, and Quake Champions.
 	YawDegPerCountSource = 0.022
 
-	// Yaw shared by Overwatch, Call of Duty, and Destiny 2 (0.0066 deg/count).
+	// Overwatch family yaw (0.0066 deg/count) shared by Overwatch, Call of
+	// Duty, and Destiny 2.
 	YawDegPerCountOverwatch = 0.0066
 
-	// Valorant yaw (0.06996 deg/count), per Kovaak's FovSensConfig.json.
-	YawDegPerCountValorant = 0.06996
+	// Single-game scales (one constant per Kovaak's Sens Scale entry).
+	YawDegPerCountValorant        = 0.06996
+	YawDegPerCountHalo            = 0.022222
+	YawDegPerCountFortnite        = 0.005555
+	YawDegPerCountDiabotical      = 1.0 / 60.0
+	YawDegPerCountRust            = 0.1125
+	YawDegPerCountUE4             = 0.07
+	YawDegPerCountHuntShowdown    = 0.0429718162181364
+	YawDegPerCountGundamEvolution = 0.0003888500001
+	YawDegPerCountTheFinals       = 0.001
+	YawDegPerCountRoblox          = 1.01061008
+	YawDegPerCountRobloxArsenal   = 0.375
+	YawDegPerCountMarvelRivals    = 0.0175
+	YawDegPerCountDeadlock        = 0.044
+	YawDegPerCountFragpunk        = 0.05555
+	YawDegPerCountStrinova        = 0.01388194363
+	YawDegPerCountDeltaForce      = 0.03
+	YawDegPerCountBatallion       = 0.017501
+
+	// Shared by Rainbow 6: Siege and Reflex Arena.
+	YawDegPerCountSiege = 0.018 / math.Pi
 )

--- a/internal/constants/defaults.go
+++ b/internal/constants/defaults.go
@@ -32,6 +32,13 @@ const (
 	// by the sensitivity converter to derive cm/360 for linear engines where
 	// rotation = sensitivity * yaw * counts.
 
-	// Source-family defaults used by Counter-Strike and Apex Legends
+	// Source-family yaw (0.022 deg/count) shared by Counter-Strike, CSGO,
+	// Apex Legends, Quake/Source, and Quake Champions.
 	YawDegPerCountSource = 0.022
+
+	// Yaw shared by Overwatch, Call of Duty, and Destiny 2 (0.0066 deg/count).
+	YawDegPerCountOverwatch = 0.0066
+
+	// Valorant yaw (0.06996 deg/count), per Kovaak's FovSensConfig.json.
+	YawDegPerCountValorant = 0.06996
 )

--- a/internal/runs/sens_convert.go
+++ b/internal/runs/sens_convert.go
@@ -48,7 +48,8 @@ func cm360FromStats(stats map[string]any) (float64, bool) {
 }
 
 // yawByScale maps Kovaak's "Sens Scale" string to the corresponding yaw
-// constant (degrees of rotation per mouse count at sensitivity 1.0).
+// constant from internal/constants (degrees of rotation per mouse count at
+// sensitivity 1.0).
 //
 // Values are sourced from Kovaak's official FovSensConfig.json. Only scales
 // using a linear IncrementFormula of the form "Sens * yaw" are listed here.
@@ -67,28 +68,28 @@ var yawByScale = map[string]float64{
 	"Call of Duty": constants.YawDegPerCountOverwatch,
 	"Destiny 2":    constants.YawDegPerCountOverwatch,
 
-	// Riot
-	"Valorant": constants.YawDegPerCountValorant,
+	// Single-game scales
+	"Valorant":         constants.YawDegPerCountValorant,
+	"Halo":             constants.YawDegPerCountHalo,
+	"Fortnite":         constants.YawDegPerCountFortnite,
+	"Diabotical":       constants.YawDegPerCountDiabotical,
+	"Rust":             constants.YawDegPerCountRust,
+	"UE4":              constants.YawDegPerCountUE4,
+	"Hunt: Showdown":   constants.YawDegPerCountHuntShowdown,
+	"Gundam Evolution": constants.YawDegPerCountGundamEvolution,
+	"The FINALS":       constants.YawDegPerCountTheFinals,
+	"Roblox":           constants.YawDegPerCountRoblox,
+	"Roblox Arsenal":   constants.YawDegPerCountRobloxArsenal,
+	"Marvel Rivals":    constants.YawDegPerCountMarvelRivals,
+	"Deadlock":         constants.YawDegPerCountDeadlock,
+	"Fragpunk":         constants.YawDegPerCountFragpunk,
+	"Strinova":         constants.YawDegPerCountStrinova,
+	"Delta Force":      constants.YawDegPerCountDeltaForce,
+	"Batallion":        constants.YawDegPerCountBatallion,
 
-	// Unique scales
-	"Halo":              0.022222,
-	"Fortnite":          0.005555,
-	"Diabotical":        1.0 / 60.0,
-	"Rust":              0.1125,
-	"UE4":               0.07,
-	"Hunt: Showdown":    0.0429718162181364,
-	"Gundam Evolution":  0.0003888500001,
-	"The FINALS":        0.001,
-	"Roblox":            1.01061008,
-	"Roblox Arsenal":    0.375,
-	"Marvel Rivals":     0.0175,
-	"Deadlock":          0.044,
-	"Fragpunk":          0.05555,
-	"Strinova":          0.01388194363,
-	"Delta Force":       0.03,
-	"Batallion":         0.017501,
-	"Rainbow 6: Siege":  0.018 / math.Pi,
-	"Reflex Arena":      0.018 / math.Pi,
+	// Shared yaw (0.018 / pi)
+	"Rainbow 6: Siege": constants.YawDegPerCountSiege,
+	"Reflex Arena":     constants.YawDegPerCountSiege,
 }
 
 func toFloat(v any) float64 {

--- a/internal/runs/sens_convert.go
+++ b/internal/runs/sens_convert.go
@@ -47,10 +47,48 @@ func cm360FromStats(stats map[string]any) (float64, bool) {
 	return cm360(scale, s, dpi)
 }
 
+// yawByScale maps Kovaak's "Sens Scale" string to the corresponding yaw
+// constant (degrees of rotation per mouse count at sensitivity 1.0).
+//
+// Values are sourced from Kovaak's official FovSensConfig.json. Only scales
+// using a linear IncrementFormula of the form "Sens * yaw" are listed here.
+// Non-linear scales (Splitgate, Paladins, PUBG, Battlefield V/1/6, GTA 5)
+// depend on FOV or use affine formulas and are intentionally omitted.
 var yawByScale = map[string]float64{
-	"Apex Legends":   constants.YawDegPerCountSource,
-	"CSGO":           constants.YawDegPerCountSource,
-	"Counter-Strike": constants.YawDegPerCountSource,
+	// Source family (yaw 0.022)
+	"Quake/Source":    constants.YawDegPerCountSource,
+	"Quake Champions": constants.YawDegPerCountSource,
+	"Apex Legends":    constants.YawDegPerCountSource,
+	"Counter-Strike":  constants.YawDegPerCountSource,
+	"CSGO":            constants.YawDegPerCountSource,
+
+	// Overwatch family (yaw 0.0066)
+	"Overwatch":    constants.YawDegPerCountOverwatch,
+	"Call of Duty": constants.YawDegPerCountOverwatch,
+	"Destiny 2":    constants.YawDegPerCountOverwatch,
+
+	// Riot
+	"Valorant": constants.YawDegPerCountValorant,
+
+	// Unique scales
+	"Halo":              0.022222,
+	"Fortnite":          0.005555,
+	"Diabotical":        1.0 / 60.0,
+	"Rust":              0.1125,
+	"UE4":               0.07,
+	"Hunt: Showdown":    0.0429718162181364,
+	"Gundam Evolution":  0.0003888500001,
+	"The FINALS":        0.001,
+	"Roblox":            1.01061008,
+	"Roblox Arsenal":    0.375,
+	"Marvel Rivals":     0.0175,
+	"Deadlock":          0.044,
+	"Fragpunk":          0.05555,
+	"Strinova":          0.01388194363,
+	"Delta Force":       0.03,
+	"Batallion":         0.017501,
+	"Rainbow 6: Siege":  0.018 / math.Pi,
+	"Reflex Arena":      0.018 / math.Pi,
 }
 
 func toFloat(v any) float64 {

--- a/internal/runs/sens_convert_test.go
+++ b/internal/runs/sens_convert_test.go
@@ -1,0 +1,125 @@
+package runs
+
+import (
+	"math"
+	"testing"
+)
+
+const cm360Tolerance = 0.001 // cm
+
+func TestCm360DirectEntries(t *testing.T) {
+	cases := []struct {
+		name      string
+		scale     string
+		horizSens float64
+		want      float64
+	}{
+		{"cm/360 passes through", "cm/360", 30.0, 30.0},
+		{"in/360 converts to cm", "in/360", 12.0, 12.0 * 2.54},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := cm360(tc.scale, tc.horizSens, 800)
+			if !ok {
+				t.Fatalf("expected ok=true, got false")
+			}
+			if math.Abs(got-tc.want) > cm360Tolerance {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCm360GameScales(t *testing.T) {
+	// Expected values are derived from the Kovaak's-published yaw constants.
+	// If any of these break, either the yaw map drifted from Kovaak's
+	// FovSensConfig.json or the conversion formula was changed.
+	cases := []struct {
+		scale     string
+		horizSens float64
+		dpi       float64
+		want      float64
+	}{
+		{"CSGO", 2.0, 800, 25.9773},
+		{"Counter-Strike", 1.0, 800, 51.9545},
+		{"Apex Legends", 1.6, 800, 32.4716},
+		{"Quake/Source", 3.5, 400, 29.6883},
+		{"Valorant", 0.44479, 800, 36.7320},
+		{"Fortnite", 7.5, 800, 27.4347},
+		{"Overwatch", 5.0, 800, 34.6364},
+		{"Call of Duty", 6.0, 1600, 14.4318},
+		{"Halo", 5.0, 800, 10.2872},
+		{"Rust", 1.0, 800, 10.1600},
+		{"Marvel Rivals", 50.0, 800, 1.3071},
+	}
+	for _, tc := range cases {
+		t.Run(tc.scale, func(t *testing.T) {
+			got, ok := cm360(tc.scale, tc.horizSens, tc.dpi)
+			if !ok {
+				t.Fatalf("expected ok=true, got false")
+			}
+			if math.Abs(got-tc.want) > 0.01 {
+				t.Fatalf("got %v, want %v (delta %v)", got, tc.want, got-tc.want)
+			}
+		})
+	}
+}
+
+func TestCm360UnknownScale(t *testing.T) {
+	if _, ok := cm360("NotARealGame", 2.0, 800); ok {
+		t.Fatalf("expected ok=false for unknown scale")
+	}
+	// Empty scale should also fail.
+	if _, ok := cm360("", 2.0, 800); ok {
+		t.Fatalf("expected ok=false for empty scale")
+	}
+}
+
+func TestCm360InvalidInputs(t *testing.T) {
+	cases := []struct {
+		name      string
+		scale     string
+		horizSens float64
+		dpi       float64
+	}{
+		{"zero sens", "CSGO", 0, 800},
+		{"negative sens", "CSGO", -1, 800},
+		{"zero dpi", "CSGO", 2.0, 0},
+		{"negative dpi", "CSGO", 2.0, -100},
+		{"NaN sens", "CSGO", math.NaN(), 800},
+		{"+Inf sens", "CSGO", math.Inf(1), 800},
+		{"zero direct cm/360", "cm/360", 0, 800},
+		{"negative direct in/360", "in/360", -5, 800},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := cm360(tc.scale, tc.horizSens, tc.dpi); ok {
+				t.Fatalf("expected ok=false for invalid input")
+			}
+		})
+	}
+}
+
+func TestCm360FromStats(t *testing.T) {
+	// Mimics a parsed Kovaak's CSV: values come in as strings.
+	stats := map[string]any{
+		"Sens Scale": "Valorant",
+		"Horiz Sens": "0.44479",
+		"DPI":        "800",
+	}
+	got, ok := cm360FromStats(stats)
+	if !ok {
+		t.Fatalf("expected ok=true, got false")
+	}
+	if math.Abs(got-36.7320) > 0.01 {
+		t.Fatalf("got %v, want ~36.7320", got)
+	}
+
+	// Nil and unknown-scale maps should fail.
+	if _, ok := cm360FromStats(nil); ok {
+		t.Fatalf("expected ok=false for nil stats")
+	}
+	if _, ok := cm360FromStats(map[string]any{"Sens Scale": "Unknown", "Horiz Sens": "1.0", "DPI": "800"}); ok {
+		t.Fatalf("expected ok=false for unknown scale via stats")
+	}
+}


### PR DESCRIPTION
## Summary

Adds yaw constants for **27 game scales** that Kovaak's supports but Refleks didn't yet recognize: Valorant, Fortnite, Overwatch, Call of Duty, Quake/Source, Quake Champions, Halo, Rust, Destiny 2, UE4, Hunt: Showdown, The FINALS, Roblox, Roblox Arsenal, Marvel Rivals, Deadlock, Fragpunk, Strinova, Delta Force, Batallion, Rainbow 6: Siege, Reflex Arena, Diabotical, and Gundam Evolution.

Fixes #24.

## Background

Before this PR, `yawByScale` (in `internal/runs/sens_convert.go`) only contained CSGO, Counter-Strike, and Apex Legends. Users on any other Sens Scale hit the default branch in `cm360()`, which returned `(0, false)`, so the stat was never set in the ingest pipeline. The frontend's `computeSuggestedSens` then bailed because `cm/360` was missing/zero — surfacing as "Sensitivity Suggestion Unavailable" and `cm/360 = 0` in the Controls panel.

## Source of values

All yaw values come from Kovaak's official `FovSensConfig.json` — the file the game downloads from The Meta's servers at startup and stores under `FPSAimTrainer/Saved/SaveGames/`. Each entry there has an `IncrementFormula: "Sens * <yaw>"` from which the yaw constant is extracted directly.

Using Kovaak's own values (rather than third-party tables) means cm/360 computed by Refleks matches what Kovaak's itself shows on its sensitivity slider, by construction.

## Out of scope

Scales using non-linear formulas are intentionally **not** added in this PR, since they don't fit the current `cm/360 = 360 / (sens * dpi * yaw) * 2.54` model:

| Scale | Reason |
|---|---|
| Splitgate, Paladins | Yaw depends on FOV (`Sens * k * FOV * 0.001`) |
| PUBG | Exponential x FOV |
| Battlefield V/1/Hardline, Battlefield 6 | Affine: `Sens * a + b` |
| GTA 5 | Affine |

These can be added in a follow-up by extending the converter to accept either a function or a richer scale descriptor. Happy to do that in a separate PR if maintainers are interested.

## New constants

In `internal/constants/defaults.go`:
- `YawDegPerCountOverwatch = 0.0066` - shared by Overwatch, Call of Duty, Destiny 2
- `YawDegPerCountValorant = 0.06996`

Other unique yaw values stay inline in the map.

## Tests

Adds `internal/runs/sens_convert_test.go` - the first Go test file in the repo. Covers:

- `cm/360` direct -> identity
- `in/360` direct -> x2.54 conversion
- Game scales (CSGO, Counter-Strike, Apex Legends, Quake/Source, Valorant, Fortnite, Overwatch, Call of Duty, Halo, Rust, Marvel Rivals) -> exact expected cm/360 within 0.01
- Unknown / empty scale -> `ok=false`
- Invalid inputs (zero, negative, NaN, +Inf) -> `ok=false`
- `cm360FromStats` with parsed-CSV-like map (string values)

Run with: `go test ./internal/runs/...`

## Verification

- `go vet ./internal/...` - clean
- `go build ./internal/...` - clean
- `go test ./internal/runs/...` - 23 cases, all pass
- Tested locally with a real Kovaak's Valorant run (`Horiz Sens: 0.44479`, `DPI: 800`) -> `cm/360 ~= 36.73`, matches mouse-sensitivity.com.

## Test plan
- [ ] `go test ./internal/runs/...` passes
- [ ] Loading a run with `Sens Scale: Valorant` in the UI shows a non-zero `cm/360` and "Sensitivity Suggestion" is no longer marked Unavailable
- [ ] Loading a run with `Sens Scale: CSGO` (already supported pre-PR) still works identically